### PR TITLE
fix(audit): resolve npm audit vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "@types/react-dom": "^17.0.9",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-scripts": "4.0.3",
     "typescript": "^4.4.3",
     "web-vitals": "^1.1.2"
   },
@@ -41,6 +40,7 @@
     ]
   },
   "devDependencies": {
+    "react-scripts": "4.0.3",
     "eslint-config-prettier": "^8.3.0",
     "prettier": "2.4.1",
     "@typescript-eslint/eslint-plugin": "^4.31.2",


### PR DESCRIPTION
Move `react-scripts` from `dependencies` to `devDependencies` to resolve
production vulnerabilities.

Closes #10