### PR TITLE
feat(PokeDetail): add type information

### DIFF
--- a/src/PokeDetail/PokeDetail.tsx
+++ b/src/PokeDetail/PokeDetail.tsx
@@ -14,6 +14,13 @@ export interface Props {
   setIsOpen: SetIsOpen;
 }
 
+export interface TypeEntry {
+  /** The number of the type. */
+  slot: number;
+  /** A mapping of the type name and URL. */
+  type: Record<string, string>;
+}
+
 export interface FlavorTextEntry {
   /** The flavor text sentence. */
   flavor_text: string;
@@ -42,6 +49,7 @@ const PokeDetail = ({
 }: Props): ReactElement => {
   const [pokemonName, setPokemonName] = useState<string>("");
   const [pokemonSpriteUrl, setPokemonSpriteUrl] = useState<string>("");
+  const [pokemonTypes, setPokemonTypes] = useState<string[]>([]);
   const [pokemonFlavorTexts, setPokemonFlavorTexts] = useState<FlavorText[]>(
     []
   );
@@ -55,8 +63,9 @@ const PokeDetail = ({
     fetch(`${BASE_URL}pokemon/${pokemonNumber}`)
       .then((response) => response.json())
       .then((data) => {
-        setPokemonSpriteUrl(data.sprites.front_default);
         setPokemonName(data.name);
+        setPokemonSpriteUrl(data.sprites.front_default);
+        setPokemonTypes(data.types.map((entry: TypeEntry) => entry.type.name));
       });
     fetch(`${BASE_URL}pokemon-species/${pokemonNumber}`)
       .then((response) => response.json())
@@ -154,6 +163,13 @@ const PokeDetail = ({
                         ? capitalize(pokemonHabitat)
                         : "N/A"}
                     </p>
+                    <div className="w-full pt-3 flex flex-row justify-items-start">
+                      {pokemonTypes.map((type) => (
+                        <p key={type} className="mr-3">
+                          {capitalize(type)}
+                        </p>
+                      ))}
+                    </div>
                   </div>
                   <div className="mt-4">
                     <button

--- a/src/PokeDetail/PokeDetail.tsx
+++ b/src/PokeDetail/PokeDetail.tsx
@@ -150,8 +150,14 @@ const PokeDetail = ({
                   >
                     {capitalize(pokemonName)}, the {pokemonGenus}
                   </Dialog.Title>
-                  <div className="mt-2 text-left flex flex-col justify-center items-center">
-                    <img src={pokemonSpriteUrl}></img>
+                  <div className="mt-2 text-left flex flex-col items-center">
+                    <div className="w-24 h-24 rounded-full bg-gray-200 my-4">
+                      <img
+                        src={pokemonSpriteUrl}
+                        alt={"An image of " + pokemonName}
+                      ></img>
+                    </div>
+
                     {pokemonFlavorTexts.length > 0 ? (
                       <p>{pokemonFlavorTexts[0].text}</p>
                     ) : null}

--- a/src/PokeDetail/PokeDetail.tsx
+++ b/src/PokeDetail/PokeDetail.tsx
@@ -1,4 +1,5 @@
 import React, { Fragment, ReactElement, useEffect, useState } from "react";
+import PokeDetailTypes from "./PokeDetailTypes";
 import { Dialog, Transition } from "@headlessui/react";
 import { BASE_URL, capitalize } from "../utils";
 
@@ -163,13 +164,7 @@ const PokeDetail = ({
                         ? capitalize(pokemonHabitat)
                         : "N/A"}
                     </p>
-                    <div className="w-full pt-3 flex flex-row justify-items-start">
-                      {pokemonTypes.map((type) => (
-                        <p key={type} className="mr-3">
-                          {capitalize(type)}
-                        </p>
-                      ))}
-                    </div>
+                    <PokeDetailTypes pokemonTypes={pokemonTypes} />
                   </div>
                   <div className="mt-4">
                     <button

--- a/src/PokeDetail/PokeDetailTypes.tsx
+++ b/src/PokeDetail/PokeDetailTypes.tsx
@@ -63,7 +63,9 @@ const PokeDetailTypes = ({ pokemonTypes }: Props): ReactElement => {
       {pokemonTypes.map((type) => (
         <p
           key={type}
-          className={"mr-3 p-1 font-bold rounded-md " + getColor(type)}
+          className={
+            "mr-3 p-1 font-bold rounded-md text-white " + getColor(type)
+          }
         >
           {type.toUpperCase()}
         </p>

--- a/src/PokeDetail/PokeDetailTypes.tsx
+++ b/src/PokeDetail/PokeDetailTypes.tsx
@@ -1,0 +1,75 @@
+import React, { ReactElement } from "react";
+
+export interface Props {
+  /** The types of the Pokémon. */
+  pokemonTypes: string[];
+}
+
+/**
+ * A way to get the matching color of the type.
+ * @param type The type to "look up".
+ * @returns The matching color of `type`.
+ */
+const getColor = (type: string): string => {
+  switch (type) {
+    case "normal":
+      return "bg-gray-500";
+    case "fighting":
+      return "bg-red-500";
+    case "flying":
+      return "bg-purple-400";
+    case "poison":
+      return "bg-purple-800";
+    case "ground":
+      return "bg-yellow-300";
+    case "rock":
+      return "bg-yellow-500";
+    case "bug":
+      return "bg-green-400";
+    case "ghost":
+      return "bg-purple-500";
+    case "steel":
+      return "bg-gray-400";
+    case "fire":
+      return "bg-yellow-500";
+    case "water":
+      return "bg-blue-500";
+    case "grass":
+      return "bg-green-700";
+    case "electric":
+      return "bg-yellow-300";
+    case "psychic":
+      return "bg-pink-400";
+    case "ice":
+      return "bg-blue-200";
+    case "dragon":
+      return "bg-purple-900";
+    case "dark":
+      return "bg-gray-700";
+    case "fairy":
+      return "bg-pink-300";
+    case "unknown":
+      return "bg-green-500";
+    case "shadow":
+      return "bg-gray-700";
+    default:
+      return "bg-gray-500";
+  }
+};
+
+const PokeDetailTypes = ({ pokemonTypes }: Props): ReactElement => {
+  return (
+    <div className="w-full pt-3 flex flex-row justify-items-start">
+      {pokemonTypes.map((type) => (
+        <p
+          key={type}
+          className={"mr-3 p-1 font-bold rounded-md " + getColor(type)}
+        >
+          {type.toUpperCase()}
+        </p>
+      ))}
+    </div>
+  );
+};
+
+export default PokeDetailTypes;

--- a/src/PokeDetail/PokeDetailTypes.tsx
+++ b/src/PokeDetail/PokeDetailTypes.tsx
@@ -10,7 +10,7 @@ export interface Props {
  * @param type The type to "look up".
  * @returns The matching color of `type`.
  */
-const getColor = (type: string): string => {
+export const getColor = (type: string): string => {
   switch (type) {
     case "normal":
       return "bg-gray-500";
@@ -23,7 +23,7 @@ const getColor = (type: string): string => {
     case "ground":
       return "bg-yellow-300";
     case "rock":
-      return "bg-yellow-500";
+      return "bg-yellow-600";
     case "bug":
       return "bg-green-400";
     case "ghost":

--- a/src/PokeListItem/PokeListItem.tsx
+++ b/src/PokeListItem/PokeListItem.tsx
@@ -75,7 +75,7 @@ const PokeListItem = ({
         ) : null}
       </div>
       <p>
-        <span className="text-gray-500">#{pokemonId}</span>{" "}
+        <span className="text-gray-600 dark:text-gray-300">#{pokemonId}</span>{" "}
         {capitalize(pokemonName)}
       </p>
     </section>


### PR DESCRIPTION
Add the type(s) of the selected Pokemon in the PokeDetail dialog.

Closes #53